### PR TITLE
Building the project (phase: test) anyway requires argline be present

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -281,6 +281,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
+                    <configuration>
+                        <argLine>-Djava.net.preferIPv4Stack=true</argLine>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The parameter: -Djava.net.preferIPv4Stack=true
is required to run test, to run nodes.

Instead of relying on user's configuration, explicit this parameter in
the surefire maven plugin config.