### PR TITLE
Added test for DROOLS-1328 https://issues.jboss.org/browse/DROOLS-1328

### DIFF
--- a/hacep-core/pom.xml
+++ b/hacep-core/pom.xml
@@ -78,4 +78,20 @@
         </dependency>
     </dependencies>
 
+    <!-- TODO: remove when bump brms version to >= 6.4 (or drools >= 6.5) -->
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/TestSerializedRetractRules.java</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/hacep-core/src/test/java/it/redhat/hacep/cluster/TestDroolsConfiguration.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/cluster/TestDroolsConfiguration.java
@@ -40,6 +40,18 @@ public class TestDroolsConfiguration implements DroolsConfiguration {
     private TestDroolsConfiguration() {
     }
 
+    public static TestDroolsConfiguration buildRulesWithGamePlayRetract() {
+        try {
+            TestDroolsConfiguration droolsConfiguration = new TestDroolsConfiguration();
+            ReleaseIdImpl releaseId = new ReleaseIdImpl("it.redhat.jdg", "rules", "1.0.0");
+            droolsConfiguration.kieContainer = KieAPITestUtils.setupKieContainer(releaseId, "pom/pom-1.0.0.xml", "rules/gameplay_retract.drl");
+            droolsConfiguration.kieBase = droolsConfiguration.kieContainer.getKieBase();
+            return droolsConfiguration;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     public static TestDroolsConfiguration buildRulesWithRetract() {
         try {
             TestDroolsConfiguration droolsConfiguration = new TestDroolsConfiguration();

--- a/hacep-core/src/test/java/it/redhat/hacep/rules/TestSerializedRetractRules.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/rules/TestSerializedRetractRules.java
@@ -1,0 +1,82 @@
+package it.redhat.hacep.rules;
+
+import it.redhat.hacep.cluster.TestDroolsConfiguration;
+import it.redhat.hacep.drools.KieSessionByteArraySerializer;
+import it.redhat.hacep.model.Fact;
+import it.redhat.hacep.rules.model.Gameplay;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.api.runtime.Channel;
+import org.kie.api.runtime.KieSession;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestSerializedRetractRules {
+
+    private final static Logger logger = LoggerFactory.getLogger(TestSerializedRetractRules.class);
+
+    private static TestDroolsConfiguration droolsConfiguration = TestDroolsConfiguration.buildRulesWithGamePlayRetract();
+
+    private static KieSessionByteArraySerializer serializer = new KieSessionByteArraySerializer(droolsConfiguration);
+
+    private ZonedDateTime now;
+
+    @Mock
+    private Channel outcomesChannel;
+
+    @Before
+    public void init() {
+        now = ZonedDateTime.now();
+    }
+
+    @Test
+    public void testSessionSerialization() {
+        logger.info("Start test serialized rules");
+        reset(outcomesChannel);
+
+        KieSession kieSession = droolsConfiguration.getKieSession();
+        kieSession.registerChannel("outcomes", outcomesChannel);
+
+        kieSession.insert(generateFactTenSecondsAfter(1));
+        kieSession.fireAllRules();
+
+        verify(outcomesChannel, times(1)).send(any());
+        verifyNoMoreInteractions(outcomesChannel);
+
+        reset(outcomesChannel);
+
+        byte[] kieSessionBytes = serializer.writeObject(kieSession);
+        Assert.assertTrue(kieSessionBytes.length > 0);
+        kieSession.dispose();
+
+        KieSession kieSessionDeserialized = serializer.readSession(kieSessionBytes);
+        kieSessionDeserialized.registerChannel("outcomes", outcomesChannel);
+
+        kieSessionDeserialized.insert(generateFactTenSecondsAfter(1));
+        kieSessionDeserialized.fireAllRules();
+
+        verify(outcomesChannel, times(1)).send(any());
+        verifyNoMoreInteractions(outcomesChannel);
+
+        logger.info("End test serialized rules");
+    }
+
+    private Fact generateFactTenSecondsAfter(long ppid) {
+        now = now.plusSeconds(10);
+        return new Gameplay(ppid, ppid, new Date(now.toInstant().toEpochMilli()));
+    }
+}

--- a/hacep-core/src/test/java/it/redhat/hacep/rules/model/Gameplay.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/rules/model/Gameplay.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.rules.model;
+
+import it.redhat.hacep.model.Fact;
+import it.redhat.hacep.model.Key;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.Objects;
+
+public class Gameplay implements Fact {
+
+    private static final long serialVersionUID = 7517352753296362943L;
+
+    protected long id;
+
+    protected Long playerId;
+
+    protected Date timestamp;
+
+    public Gameplay(long id, Long playerId, Date timestamp) {
+        this.id = id;
+        this.playerId = playerId;
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public Instant getInstant() {
+        return timestamp.toInstant();
+    }
+
+    @Override
+    public Key extractKey() {
+        return new GameplayKey(String.valueOf(id), String.valueOf(playerId));
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    public Long getPlayerId() {
+        return playerId;
+    }
+
+    public void setPlayerId(Long playerId) {
+        this.playerId = playerId;
+    }
+
+    public Date getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Gameplay)) return false;
+        Gameplay gameplay = (Gameplay) o;
+        return id == gameplay.id &&
+                Objects.equals(playerId, gameplay.playerId) &&
+                Objects.equals(timestamp, gameplay.timestamp);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, playerId, timestamp);
+    }
+
+    @Override
+    public String toString() {
+        return "GamePlay{" +
+                "id=" + id +
+                ", playerId=" + playerId +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/hacep-core/src/test/java/it/redhat/hacep/rules/model/GameplayKey.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/rules/model/GameplayKey.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.rules.model;
+
+import it.redhat.hacep.model.Key;
+
+import java.util.Objects;
+
+public class GameplayKey extends Key<String> {
+
+    private String id;
+
+    public GameplayKey(String id, String player) {
+        super(player);
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String toString() {
+        return id + "::" + getGroup();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GameplayKey)) return false;
+        if (!super.equals(o)) return false;
+        GameplayKey gameplayKey = (GameplayKey) o;
+        return Objects.equals(id, gameplayKey.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), id);
+    }
+
+}

--- a/hacep-core/src/test/resources/rules/gameplay_retract.drl
+++ b/hacep-core/src/test/resources/rules/gameplay_retract.drl
@@ -1,0 +1,20 @@
+package it.redhat.hacep.rules.reward.catalog;
+
+import it.redhat.hacep.rules.model.Gameplay;
+
+declare Gameplay
+    @role( event )
+    @timestamp ( instant.toEpochMilli() )
+    @expires( 60d )
+end
+
+rule "retract test rule"
+salience 10
+when
+    $gamePlay : Gameplay($playerId : playerId) over window:length(1)
+then
+	retract($gamePlay);
+	channels["outcomes"].send($playerId + " plays game");
+	System.out.println("GamePlay["+$gamePlay+"] retracted");
+end
+


### PR DESCRIPTION
test is disabled in hacep-core/pom.xm through surefire plugin config because is failing,
enable it when brms version is bumped to >= 6.4 or drools (fro community profile) to >= 6.5
