### PR TITLE
Manual kjar update

### DIFF
--- a/hacep-core-camel/src/main/java/it/redhat/hacep/camel/ResumeCommandRoute.java
+++ b/hacep-core-camel/src/main/java/it/redhat/hacep/camel/ResumeCommandRoute.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.camel;
+
+import it.redhat.hacep.HACEP;
+import it.redhat.hacep.command.model.ResponseCode;
+import it.redhat.hacep.command.model.ResponseMessage;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.builder.RouteBuilder;
+
+public class ResumeCommandRoute extends RouteBuilder {
+
+    private final HACEP hacep;
+
+    public ResumeCommandRoute(HACEP hacep) {
+        this.hacep = hacep;
+    }
+
+    @Override
+    public void configure() throws Exception {
+        from("direct:RESUME")
+                .onException(Exception.class)
+                .maximumRedeliveries(0)
+                .handled(true)
+                .process(exchange -> {
+                    Exception exception = (Exception) exchange.getProperty(Exchange.EXCEPTION_CAUGHT);
+                    exchange.getOut().setBody(new ResponseMessage(ResponseCode.ERROR, exception.getMessage()));
+                })
+                .to("direct:marshal-response")
+                .end()
+                .setExchangePattern(ExchangePattern.InOut)
+                .bean(hacep, "resume()", false)
+                .process(exchange -> {
+                    ResponseMessage output = new ResponseMessage(ResponseCode.SUCCESS, "OK");
+                    exchange.getOut().setBody(output);
+                })
+                .to("direct:marshal-response");
+    }
+}

--- a/hacep-core-camel/src/main/java/it/redhat/hacep/camel/SuspendCommandRoute.java
+++ b/hacep-core-camel/src/main/java/it/redhat/hacep/camel/SuspendCommandRoute.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.camel;
+
+import it.redhat.hacep.HACEP;
+import it.redhat.hacep.command.model.ResponseCode;
+import it.redhat.hacep.command.model.ResponseMessage;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.builder.RouteBuilder;
+
+public class SuspendCommandRoute extends RouteBuilder {
+
+    private final HACEP hacep;
+
+    public SuspendCommandRoute(HACEP hacep) {
+        this.hacep = hacep;
+    }
+
+    @Override
+    public void configure() throws Exception {
+        from("direct:SUSPEND")
+                .onException(Exception.class)
+                .maximumRedeliveries(0)
+                .handled(true)
+                .process(exchange -> {
+                    Exception exception = (Exception) exchange.getProperty(Exchange.EXCEPTION_CAUGHT);
+                    exchange.getOut().setBody(new ResponseMessage(ResponseCode.ERROR, exception.getMessage()));
+                })
+                .to("direct:marshal-response")
+                .end()
+                .setExchangePattern(ExchangePattern.InOut)
+                .bean(hacep, "suspend()", false)
+                .process(exchange -> {
+                    ResponseMessage output = new ResponseMessage(ResponseCode.SUCCESS, "OK");
+                    exchange.getOut().setBody(output);
+                })
+                .to("direct:marshal-response");
+    }
+}

--- a/hacep-core-camel/src/test/java/it/redhat/hacep/command/ResumeCommandTest.java
+++ b/hacep-core-camel/src/test/java/it/redhat/hacep/command/ResumeCommandTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.command;
+
+import it.redhat.hacep.HACEP;
+import it.redhat.hacep.camel.ResumeCommandRoute;
+import it.redhat.hacep.command.model.Command;
+import it.redhat.hacep.command.model.ResponseCode;
+import it.redhat.hacep.command.model.ResponseMessage;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.camel.builder.Builder.constant;
+import static org.apache.camel.builder.Builder.simple;
+import static org.apache.camel.builder.PredicateBuilder.isEqualTo;
+import static org.apache.camel.builder.PredicateBuilder.isInstanceOf;
+import static org.mockito.Mockito.*;
+
+public class ResumeCommandTest extends CamelTestSupport {
+
+    private HACEP hacep = mock(HACEP.class);
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new ResumeCommandRoute(hacep);
+    }
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Test
+    public void testInputCommand() throws Exception {
+        reset(hacep);
+
+        hacep.suspend();
+        
+        String expectedOutput = "OK";
+
+        context.getRouteDefinitions().get(0).adviceWith(context, new AdviceWithRouteBuilder() {
+                    @Override
+                    public void configure() throws Exception {
+                        mockEndpointsAndSkip("direct:marshal-response");
+                        replaceFromWith("direct:test");
+                    }
+                }
+        );
+
+        Command command = new Command();
+        command.setCommand("RESUME");
+
+        context.start();
+
+        getMockEndpoint("mock:direct:marshal-response").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:marshal-response")
+                .message(0)
+                .predicate(isInstanceOf(body(), ResponseMessage.class))
+                .predicate(isEqualTo(simple("${body.code}"), constant(ResponseCode.SUCCESS)))
+                .predicate(isEqualTo(simple("${body.message}"), constant(expectedOutput)));
+
+        Object object = template.requestBody("direct:test", command);
+
+        verify(hacep, times(1)).resume();
+        assertMockEndpointsSatisfied(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void testExceptionOnInputCommand() throws Exception {
+        reset(hacep);
+
+        hacep.suspend();
+        
+        String expectedOutput = "OK";
+
+        context.getRouteDefinitions().get(0).adviceWith(context, new AdviceWithRouteBuilder() {
+                    @Override
+                    public void configure() throws Exception {
+                        mockEndpointsAndSkip("direct:marshal-response");
+                        replaceFromWith("direct:test");
+                    }
+                }
+        );
+
+        Command command = new Command();
+        command.setCommand("RESUME");
+
+        doThrow(new RuntimeException("CANNOT SUSPEND ROUTE")).when(hacep).resume();
+        context.start();
+
+        getMockEndpoint("mock:direct:marshal-response").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:marshal-response")
+                .message(0)
+                .predicate(isInstanceOf(body(), ResponseMessage.class))
+                .predicate(isEqualTo(simple("${body.code}"), constant(ResponseCode.ERROR)));
+        
+        Object object = template.requestBody("direct:test", command);
+        
+        verify(hacep, times(1)).resume();
+
+        assertMockEndpointsSatisfied(1, TimeUnit.MINUTES);
+    }
+
+}

--- a/hacep-core-camel/src/test/java/it/redhat/hacep/command/SuspendCommandTest.java
+++ b/hacep-core-camel/src/test/java/it/redhat/hacep/command/SuspendCommandTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.command;
+
+import it.redhat.hacep.HACEP;
+import it.redhat.hacep.camel.SuspendCommandRoute;
+import it.redhat.hacep.command.model.Command;
+import it.redhat.hacep.command.model.KeyValueParam;
+import it.redhat.hacep.command.model.ResponseCode;
+import it.redhat.hacep.command.model.ResponseMessage;
+import org.apache.camel.RoutesBuilder;
+import org.apache.camel.builder.AdviceWithRouteBuilder;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.camel.builder.Builder.constant;
+import static org.apache.camel.builder.Builder.simple;
+import static org.apache.camel.builder.PredicateBuilder.isEqualTo;
+import static org.apache.camel.builder.PredicateBuilder.isInstanceOf;
+import static org.mockito.Mockito.*;
+
+public class SuspendCommandTest extends CamelTestSupport {
+
+    private HACEP hacep = mock(HACEP.class);
+
+    @Override
+    protected RoutesBuilder createRouteBuilder() throws Exception {
+        return new SuspendCommandRoute(hacep);
+    }
+
+    @Override
+    public boolean isUseAdviceWith() {
+        return true;
+    }
+
+    @Test
+    public void testInputCommand() throws Exception {
+        reset(hacep);
+
+        String expectedOutput = "OK";
+
+        context.getRouteDefinitions().get(0).adviceWith(context, new AdviceWithRouteBuilder() {
+                    @Override
+                    public void configure() throws Exception {
+                        mockEndpointsAndSkip("direct:marshal-response");
+                        replaceFromWith("direct:test");
+                    }
+                }
+        );
+
+        Command command = new Command();
+        command.setCommand("SUSPEND");
+
+        context.start();
+
+        getMockEndpoint("mock:direct:marshal-response").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:marshal-response")
+                .message(0)
+                .predicate(isInstanceOf(body(), ResponseMessage.class))
+                .predicate(isEqualTo(simple("${body.code}"), constant(ResponseCode.SUCCESS)))
+                .predicate(isEqualTo(simple("${body.message}"), constant(expectedOutput)));
+
+        Object object = template.requestBody("direct:test", command);
+
+        verify(hacep, times(1)).suspend();
+        assertMockEndpointsSatisfied(1, TimeUnit.MINUTES);
+    }
+
+    @Test
+    public void testExceptionOnInputCommand() throws Exception {
+        reset(hacep);
+
+        String expectedOutput = "OK";
+
+        context.getRouteDefinitions().get(0).adviceWith(context, new AdviceWithRouteBuilder() {
+                    @Override
+                    public void configure() throws Exception {
+                        mockEndpointsAndSkip("direct:marshal-response");
+                        replaceFromWith("direct:test");
+                    }
+                }
+        );
+
+        Command command = new Command();
+        command.setCommand("SUSPEND");
+
+        doThrow(new RuntimeException("CANNOT SUSPEND ROUTE")).when(hacep).suspend();
+        context.start();
+
+        getMockEndpoint("mock:direct:marshal-response").expectedMessageCount(1);
+        getMockEndpoint("mock:direct:marshal-response")
+                .message(0)
+                .predicate(isInstanceOf(body(), ResponseMessage.class))
+                .predicate(isEqualTo(simple("${body.code}"), constant(ResponseCode.ERROR)));
+
+        Object object = template.requestBody("direct:test", command);
+
+
+        verify(hacep, times(1)).suspend();
+
+        assertMockEndpointsSatisfied(1, TimeUnit.MINUTES);
+    }
+
+}

--- a/hacep-core/src/main/java/it/redhat/hacep/HACEPImpl.java
+++ b/hacep-core/src/main/java/it/redhat/hacep/HACEPImpl.java
@@ -88,8 +88,8 @@ public class HACEPImpl implements HACEP {
                 this.rulesManager.start(groupId, artifactId, version);
                 infoCache.addListener(new UpdateVersionListener(this.router, this.rulesManager));
 
-                infoCache.put(Router.SUSPEND, "0");
-                infoCache.put(Router.RESUME, "0");
+                infoCache.putIfAbsent(Router.SUSPEND, "0");
+                infoCache.putIfAbsent(Router.RESUME, "0");
                 infoCache.addListener(new SuspendResumeListener(this.router));
 
                 rulesUpdateVersion = new RulesUpdateVersionImpl(dataGridManager.getReplicatedCache());

--- a/hacep-core/src/main/java/it/redhat/hacep/HACEPImpl.java
+++ b/hacep-core/src/main/java/it/redhat/hacep/HACEPImpl.java
@@ -19,10 +19,7 @@ package it.redhat.hacep;
 
 import it.redhat.hacep.cache.PutterImpl;
 import it.redhat.hacep.cache.RulesUpdateVersionImpl;
-import it.redhat.hacep.cache.listeners.FactListenerPost;
-import it.redhat.hacep.cache.listeners.SessionListenerPost;
-import it.redhat.hacep.cache.listeners.SessionListenerPre;
-import it.redhat.hacep.cache.listeners.UpdateVersionListener;
+import it.redhat.hacep.cache.listeners.*;
 import it.redhat.hacep.cache.session.HAKieSessionBuilder;
 import it.redhat.hacep.cache.session.KieSessionSaver;
 import it.redhat.hacep.configuration.*;
@@ -34,7 +31,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +88,10 @@ public class HACEPImpl implements HACEP {
                 this.rulesManager.start(groupId, artifactId, version);
                 infoCache.addListener(new UpdateVersionListener(this.router, this.rulesManager));
 
+                infoCache.put(Router.SUSPEND, "0");
+                infoCache.put(Router.RESUME, "0");
+                infoCache.addListener(new SuspendResumeListener(this.router));
+
                 rulesUpdateVersion = new RulesUpdateVersionImpl(dataGridManager.getReplicatedCache());
 
 
@@ -131,12 +131,16 @@ public class HACEPImpl implements HACEP {
 
     @Override
     public void suspend() {
-        this.router.suspend();
+        //this.router.suspend();
+        Cache<String, String> replicatedCache = dataGridManager.getReplicatedCache();
+        replicatedCache.put(Router.SUSPEND, String.valueOf(System.currentTimeMillis()));
     }
 
     @Override
     public void resume() {
-        this.router.resume();
+        //this.router.resume();
+        Cache<String, String> replicatedCache = dataGridManager.getReplicatedCache();
+        replicatedCache.put(Router.RESUME, String.valueOf(System.currentTimeMillis()));
     }
 
     @Override

--- a/hacep-core/src/main/java/it/redhat/hacep/cache/listeners/SuspendResumeListener.java
+++ b/hacep-core/src/main/java/it/redhat/hacep/cache/listeners/SuspendResumeListener.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.cache.listeners;
+
+import it.redhat.hacep.configuration.Router;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.CacheEntryModified;
+import org.infinispan.notifications.cachelistener.event.CacheEntryModifiedEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Listener(primaryOnly = false, sync = true, observation = Listener.Observation.POST)
+public class SuspendResumeListener {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(SuspendResumeListener.class);
+    private final Router router;
+
+
+    public SuspendResumeListener(Router router) {
+        this.router = router;
+    }
+
+    @CacheEntryModified
+    public synchronized void eventReceived(CacheEntryModifiedEvent event) {
+        Object key = event.getKey();
+        Object value = event.getValue();
+
+        if (LOGGER.isDebugEnabled()) LOGGER.debug("Received Suspend Event key=[{}] value=[{}]", key, value);
+
+        if (Router.SUSPEND.equals(key)) {
+            router.suspend();
+        }
+
+        if (Router.RESUME.equals(key)) {
+            router.resume();
+        }
+    }
+
+
+}

--- a/hacep-core/src/main/java/it/redhat/hacep/cache/listeners/UpdateVersionListener.java
+++ b/hacep-core/src/main/java/it/redhat/hacep/cache/listeners/UpdateVersionListener.java
@@ -30,11 +30,9 @@ public class UpdateVersionListener {
 
     private final Logger LOGGER = LoggerFactory.getLogger(UpdateVersionListener.class);
 
-    private final Router router;
     private final RulesManager rulesManager;
 
     public UpdateVersionListener(Router router, RulesManager rulesManager) {
-        this.router = router;
         this.rulesManager = rulesManager;
     }
 
@@ -43,9 +41,9 @@ public class UpdateVersionListener {
         Object key = event.getKey();
         Object value = event.getValue();
         if (LOGGER.isDebugEnabled()) LOGGER.debug("Received MODIFIED key on INFOS key=[{}] value=[{}]", key, value);
-        if ( (RulesManager.RULES_ARTIFACT_ID.equals(key) && !rulesManager.getReleaseId().getArtifactId().equals(key))
-                || (RulesManager.RULES_GROUP_ID.equals(key) && !rulesManager.getReleaseId().getGroupId().equals(key)) ) {
-            throw new IllegalStateException("Cannot change rules artifact or group id to ["+key+"].");
+        if ((RulesManager.RULES_ARTIFACT_ID.equals(key) && !rulesManager.getReleaseId().getArtifactId().equals(key))
+                || (RulesManager.RULES_GROUP_ID.equals(key) && !rulesManager.getReleaseId().getGroupId().equals(key))) {
+            throw new IllegalStateException("Cannot change rules artifact or group id to [" + key + "].");
         }
         if (RulesManager.RULES_VERSION.equals(key)) {
             updateVersion((String) value);
@@ -53,12 +51,7 @@ public class UpdateVersionListener {
     }
 
     private void updateVersion(String value) {
-        try {
-            router.suspend();
-            rulesManager.updateToVersion(value);
-        } finally {
-            router.resume();
-        }
+        rulesManager.updateToVersion(value);
     }
 
 }

--- a/hacep-core/src/main/java/it/redhat/hacep/configuration/Router.java
+++ b/hacep-core/src/main/java/it/redhat/hacep/configuration/Router.java
@@ -39,4 +39,7 @@ public interface Router {
      * Resume the route responsible for the messages ingestion.
      */
     void resume();
+
+    public final static String SUSPEND = "SUSPEND_ROUTE";
+    public final static String RESUME = "RESUME_ROUTE";
 }

--- a/hacep-core/src/test/java/it/redhat/hacep/cluster/TestContainerUpdate.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/cluster/TestContainerUpdate.java
@@ -259,6 +259,8 @@ public class TestContainerUpdate {
 
         reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
 
+        hacep1.suspend();
+
         // Rules Update
         try {
             hacep1.update(rulesV2.toExternalForm());
@@ -266,19 +268,9 @@ public class TestContainerUpdate {
             //let's pretend everything is ok
             LOGGER.info("TestFailedUpdate: let's pretend everything is ok");
         }
+        
+        hacep1.resume();
 
-        /* @todo check this "verify" after the new manual managing for kjar update
-
-        InOrder inOrder = Mockito.inOrder(router1);
-        inOrder.verify(router1, times(1)).suspend();
-        inOrder.verify(router1, times(1)).resume();
-        inOrder.verifyNoMoreInteractions();
-
-        inOrder = Mockito.inOrder(router2);
-        inOrder.verify(router2, times(1)).suspend();
-        inOrder.verify(router2, times(1)).resume();
-        inOrder.verifyNoMoreInteractions();
-        */
 
         Assert.assertEquals("1.0.0", hacep1.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals("1.0.0", hacep2.getRulesManager().getReleaseId().getVersion());
@@ -330,6 +322,7 @@ public class TestContainerUpdate {
 
         reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
 
+        hacep1.suspend();
         // Rules Update
         try {
             hacep1.update(rulesV2.toExternalForm());
@@ -337,33 +330,9 @@ public class TestContainerUpdate {
             //let's pretend everything is ok
             LOGGER.info("TestFailedUpdate: let's pretend everything is ok");
         }
-        /* @todo check this "verify" after the new manual managing for kjar update
-        try {
-            LOGGER.info("Let's pretend key " + RulesManager.RULES_VERSION + " is owned by node1");
-            InOrder inOrder = Mockito.inOrder(router1);
-            inOrder.verify(router1, times(1)).suspend();
-            inOrder.verify(router1, times(1)).resume();
-            inOrder.verify(router1, times(1)).suspend();
-            inOrder.verify(router1, times(1)).resume();
-            inOrder.verifyNoMoreInteractions();
 
-            inOrder = Mockito.inOrder(router2);
-            inOrder.verify(router2, times(1)).suspend();
-            inOrder.verify(router2, times(1)).resume();
-            inOrder.verifyNoMoreInteractions();
-        } catch (org.mockito.exceptions.verification.VerificationInOrderFailure e) {
-            LOGGER.info("Key " + RulesManager.RULES_VERSION + " was actually owned by node2!");
-            InOrder inOrder = Mockito.inOrder(router2);
-            inOrder.verify(router2, times(1)).suspend();
-            inOrder.verify(router2, times(1)).resume();
-            inOrder.verifyNoMoreInteractions();
+        hacep1.resume();
 
-            inOrder = Mockito.inOrder(router1);
-            inOrder.verify(router1, times(1)).suspend();
-            inOrder.verify(router1, times(1)).resume();
-            inOrder.verifyNoMoreInteractions();
-        }
-        */
         Assert.assertEquals("1.0.0", hacep1.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals("1.0.0", hacep2.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals("1.0.0", dataGridManager1.getReplicatedCache().get(RulesManager.RULES_VERSION));

--- a/hacep-core/src/test/java/it/redhat/hacep/cluster/TestContainerUpdate.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/cluster/TestContainerUpdate.java
@@ -267,6 +267,8 @@ public class TestContainerUpdate {
             LOGGER.info("TestFailedUpdate: let's pretend everything is ok");
         }
 
+        /* @todo check this "verify" after the new manual managing for kjar update
+
         InOrder inOrder = Mockito.inOrder(router1);
         inOrder.verify(router1, times(1)).suspend();
         inOrder.verify(router1, times(1)).resume();
@@ -276,6 +278,7 @@ public class TestContainerUpdate {
         inOrder.verify(router2, times(1)).suspend();
         inOrder.verify(router2, times(1)).resume();
         inOrder.verifyNoMoreInteractions();
+        */
 
         Assert.assertEquals("1.0.0", hacep1.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals("1.0.0", hacep2.getRulesManager().getReleaseId().getVersion());
@@ -334,7 +337,7 @@ public class TestContainerUpdate {
             //let's pretend everything is ok
             LOGGER.info("TestFailedUpdate: let's pretend everything is ok");
         }
-
+        /* @todo check this "verify" after the new manual managing for kjar update
         try {
             LOGGER.info("Let's pretend key " + RulesManager.RULES_VERSION + " is owned by node1");
             InOrder inOrder = Mockito.inOrder(router1);
@@ -360,7 +363,7 @@ public class TestContainerUpdate {
             inOrder.verify(router1, times(1)).resume();
             inOrder.verifyNoMoreInteractions();
         }
-
+        */
         Assert.assertEquals("1.0.0", hacep1.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals("1.0.0", hacep2.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals("1.0.0", dataGridManager1.getReplicatedCache().get(RulesManager.RULES_VERSION));

--- a/hacep-core/src/test/java/it/redhat/hacep/cluster/TestContainerUpdate.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/cluster/TestContainerUpdate.java
@@ -153,18 +153,12 @@ public class TestContainerUpdate {
 
         reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
 
+        hacep1.suspend();
+        hacep2.suspend();
         // Rules Update
         hacep1.update(rulesV2.toExternalForm());
-
-        InOrder inOrder = Mockito.inOrder(router1);
-        inOrder.verify(router1, times(1)).suspend();
-        inOrder.verify(router1, times(1)).resume();
-        inOrder.verifyNoMoreInteractions();
-
-        inOrder = Mockito.inOrder(router2);
-        inOrder.verify(router2, times(1)).suspend();
-        inOrder.verify(router2, times(1)).resume();
-        inOrder.verifyNoMoreInteractions();
+        hacep1.resume();
+        hacep2.resume();
 
         Assert.assertEquals(rulesV2.getVersion(), hacep1.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals(rulesV2.getVersion(), hacep2.getRulesManager().getReleaseId().getVersion());
@@ -184,18 +178,12 @@ public class TestContainerUpdate {
 
         reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
 
+        hacep1.suspend();
+        hacep2.suspend();
         // Rules Update
         hacep2.update(rulesV3.toExternalForm());
-
-        inOrder = Mockito.inOrder(router1);
-        inOrder.verify(router1, times(1)).suspend();
-        inOrder.verify(router1, times(1)).resume();
-        inOrder.verifyNoMoreInteractions();
-
-        inOrder = Mockito.inOrder(router2);
-        inOrder.verify(router2, times(1)).suspend();
-        inOrder.verify(router2, times(1)).resume();
-        inOrder.verifyNoMoreInteractions();
+        hacep1.resume();
+        hacep2.resume();
 
         Assert.assertEquals(rulesV3.getVersion(), hacep1.getRulesManager().getReleaseId().getVersion());
         Assert.assertEquals(rulesV3.getVersion(), hacep2.getRulesManager().getReleaseId().getVersion());
@@ -237,20 +225,20 @@ public class TestContainerUpdate {
         DataGridManager dataGridManager2 = hacep2.getDataGridManager();
 
         Set<Object> toBeRemoved = new HashSet<>();
-        for( Object listener : dataGridManager1.getReplicatedCache().getListeners() ){
-            if( listener instanceof UpdateVersionListener ) toBeRemoved.add(listener);
+        for (Object listener : dataGridManager1.getReplicatedCache().getListeners()) {
+            if (listener instanceof UpdateVersionListener) toBeRemoved.add(listener);
         }
-        for( Object listener : toBeRemoved ){
-            dataGridManager1.getReplicatedCache().removeListener( listener );
+        for (Object listener : toBeRemoved) {
+            dataGridManager1.getReplicatedCache().removeListener(listener);
         }
         dataGridManager1.getReplicatedCache().addListener(new UpdateVersionListenerError(router1, hacep1.getRulesManager()));
 
         toBeRemoved = new HashSet<>();
-        for( Object listener : dataGridManager2.getReplicatedCache().getListeners() ){
-            if( listener instanceof UpdateVersionListener ) toBeRemoved.add(listener);
+        for (Object listener : dataGridManager2.getReplicatedCache().getListeners()) {
+            if (listener instanceof UpdateVersionListener) toBeRemoved.add(listener);
         }
-        for( Object listener : toBeRemoved ){
-            dataGridManager2.getReplicatedCache().removeListener( listener );
+        for (Object listener : toBeRemoved) {
+            dataGridManager2.getReplicatedCache().removeListener(listener);
         }
         dataGridManager2.getReplicatedCache().addListener(new UpdateVersionListenerError(router2, hacep2.getRulesManager()));
 
@@ -314,11 +302,11 @@ public class TestContainerUpdate {
         DataGridManager dataGridManager2 = hacep2.getDataGridManager();
 
         Set<Object> toBeRemoved = new HashSet<>();
-        for( Object listener : dataGridManager2.getReplicatedCache().getListeners() ){
-            if( listener instanceof UpdateVersionListener ) toBeRemoved.add(listener);
+        for (Object listener : dataGridManager2.getReplicatedCache().getListeners()) {
+            if (listener instanceof UpdateVersionListener) toBeRemoved.add(listener);
         }
-        for( Object listener : toBeRemoved ){
-            dataGridManager2.getReplicatedCache().removeListener( listener );
+        for (Object listener : toBeRemoved) {
+            dataGridManager2.getReplicatedCache().removeListener(listener);
         }
         dataGridManager2.getReplicatedCache().addListener(new UpdateVersionListenerError(router2, hacep2.getRulesManager()));
 
@@ -348,7 +336,7 @@ public class TestContainerUpdate {
         }
 
         try {
-            LOGGER.info("Let's pretend key "+RulesManager.RULES_VERSION+" is owned by node1");
+            LOGGER.info("Let's pretend key " + RulesManager.RULES_VERSION + " is owned by node1");
             InOrder inOrder = Mockito.inOrder(router1);
             inOrder.verify(router1, times(1)).suspend();
             inOrder.verify(router1, times(1)).resume();
@@ -360,8 +348,8 @@ public class TestContainerUpdate {
             inOrder.verify(router2, times(1)).suspend();
             inOrder.verify(router2, times(1)).resume();
             inOrder.verifyNoMoreInteractions();
-        } catch (org.mockito.exceptions.verification.VerificationInOrderFailure e  ){
-            LOGGER.info("Key "+RulesManager.RULES_VERSION+" was actually owned by node2!");
+        } catch (org.mockito.exceptions.verification.VerificationInOrderFailure e) {
+            LOGGER.info("Key " + RulesManager.RULES_VERSION + " was actually owned by node2!");
             InOrder inOrder = Mockito.inOrder(router2);
             inOrder.verify(router2, times(1)).suspend();
             inOrder.verify(router2, times(1)).resume();

--- a/hacep-core/src/test/java/it/redhat/hacep/cluster/TestSuspendAndResume.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/cluster/TestSuspendAndResume.java
@@ -103,7 +103,8 @@ public class TestSuspendAndResume {
 
         verify(router1, times(1)).suspend();
         verify(router2, times(1)).suspend();
-
+        verify(router1, times(0)).resume();
+        verify(router2, times(0)).resume();
     }
 
     @Test

--- a/hacep-core/src/test/java/it/redhat/hacep/cluster/TestSuspendAndResume.java
+++ b/hacep-core/src/test/java/it/redhat/hacep/cluster/TestSuspendAndResume.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.redhat.hacep.cluster;
+
+import it.redhat.hacep.HACEPImpl;
+import it.redhat.hacep.configuration.JmsConfiguration;
+import it.redhat.hacep.configuration.Router;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.api.runtime.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.ZonedDateTime;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static it.redhat.hacep.cluster.RulesConfigurationTestImpl.RulesTestBuilder;
+import static org.mockito.Mockito.*;
+
+public class TestSuspendAndResume {
+
+    private final Logger LOGGER = LoggerFactory.getLogger(TestSuspendAndResume.class);
+
+    private ZonedDateTime now = ZonedDateTime.now();
+
+    private Channel additionsChannel1;
+    private Channel additionsChannel2;
+    private Channel replayChannel1;
+    private Channel replayChannel2;
+    private Router router1;
+    private Router router2;
+    private JmsConfiguration jmsConfig1;
+    private JmsConfiguration jmsConfig2;
+
+    private HACEPImpl hacep2;
+    private HACEPImpl hacep1;
+
+    @Before
+    public void setup() throws InterruptedException {
+        System.setProperty("jgroups.configuration", "jgroups-test-tcp.xml");
+
+        additionsChannel1 = mock(Channel.class);
+        additionsChannel2 = mock(Channel.class);
+        replayChannel1 = mock(Channel.class);
+        replayChannel2 = mock(Channel.class);
+        router1 = mock(Router.class);
+        router2 = mock(Router.class);
+        jmsConfig1 = mock(JmsConfiguration.class);
+        jmsConfig2 = mock(JmsConfiguration.class);
+
+        RulesConfigurationTestImpl rulesConfigurationTest1 = RulesTestBuilder.buildV1();
+        rulesConfigurationTest1.registerChannel("additions", additionsChannel1, replayChannel1);
+
+        hacep1 = new HACEPImpl("node1");
+        hacep1.setRouter(router1);
+        hacep1.setJmsConfiguration(jmsConfig1);
+        hacep1.setRulesConfiguration(rulesConfigurationTest1);
+
+        RulesConfigurationTestImpl rulesConfigurationTest2 = RulesTestBuilder.buildV1();
+        rulesConfigurationTest2.registerChannel("additions", additionsChannel2, replayChannel2);
+
+        hacep2 = new HACEPImpl("node2");
+        hacep2.setRouter(router2);
+        hacep2.setJmsConfiguration(jmsConfig2);
+        hacep2.setRulesConfiguration(rulesConfigurationTest2);
+
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        executorService.submit(hacep1::start);
+        executorService.submit(hacep2::start);
+        executorService.shutdown();
+        executorService.awaitTermination(1, TimeUnit.MINUTES);
+    }
+
+    @After
+    public void cleanup() {
+        hacep1.stop();
+        hacep2.stop();
+    }
+
+    @Test
+    public void testSuspend_from_Node1() throws InterruptedException {
+        reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
+
+        hacep1.suspend();
+
+        verify(router1, times(1)).suspend();
+        verify(router2, times(1)).suspend();
+
+    }
+
+    @Test
+    public void testSuspend_from_Node2() throws InterruptedException {
+        reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
+
+        hacep2.suspend();
+
+        verify(router1, times(1)).suspend();
+        verify(router2, times(1)).suspend();
+        verify(router1, times(0)).resume();
+        verify(router2, times(0)).resume();
+    }
+
+    @Test
+    public void testSuspend_and_resume_from_Node1() throws InterruptedException {
+        reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
+
+        hacep1.suspend();
+        hacep1.resume();
+
+        verify(router1, times(1)).suspend();
+        verify(router2, times(1)).suspend();
+
+        verify(router1, times(1)).resume();
+        verify(router2, times(1)).resume();
+    }
+
+    @Test
+    public void testSuspend_and_resume_from_Node2() throws InterruptedException {
+        reset(router1, router2, additionsChannel1, replayChannel1, additionsChannel2, replayChannel2);
+
+        hacep1.suspend();
+        hacep2.resume();
+
+        verify(router1, times(1)).suspend();
+        verify(router2, times(1)).suspend();
+
+        verify(router1, times(1)).resume();
+        verify(router2, times(1)).resume();
+    }
+}


### PR DESCRIPTION
Whit this patch it's possible to handle manually the update of the rules. 
Two new commands are added to HACEP to suspend and resume the "facts" route to stop the facts ingestion during update and once finished successfully on all nodes restart the route.